### PR TITLE
Update ChocolateyInstall.ps1

### DIFF
--- a/dotnet4.6.2/tools/ChocolateyInstall.ps1
+++ b/dotnet4.6.2/tools/ChocolateyInstall.ps1
@@ -9,7 +9,8 @@ $arguments = @{
     silentArgs = "/Passive /NoRestart /Log ""${Env:TEMP}\${packageName}.log"""
     validExitCodes = @(
         0, # success
-        3010 # success, restart required
+        3010, # success, restart required
+        5100 # success, restart required
     )
     url = $url
     checksum = $checksum


### PR DESCRIPTION
I've been getting "failures" even though this package has installed correctly. The return code is 5100, which most of the web agrees means that the system needs a restart, the difference between this and 3010 appears to be that 5100 means it was in a "requires reboot" state BEFORE the current package was installed, where 3010 means that "I triggered the reboot requirement".
