### PR TITLE
Exit script if update doesn't apply to OS

### DIFF
--- a/KB3035131/Tools/ChocolateyInstall.ps1
+++ b/KB3035131/Tools/ChocolateyInstall.ps1
@@ -1,4 +1,12 @@
-﻿$msuData = @{
+$os = Get-WmiObject -Class Win32_OperatingSystem
+$version = [Version]$os.Version
+
+if ($version -eq $null -or $version -gt [Version]'6.3') {
+	Write-Host "Skipping installation because this update only applies to Windows Vista/Server 2008 through Windows 8.1/Server 2012R2."
+	return
+}
+
+ $msuData = @{
     '6.3-client' = @{
         Url = 'https://download.microsoft.com/download/D/2/B/D2B466AA-E011-42D6-92DA-4FA8FCDAB8CB/Windows8.1-KB3035131-x86.msu'
         Checksum = '61C80C09EBE58558A7CF15F6892B392BC73A2EF669255A236562B6196FFE47C0'


### PR DESCRIPTION
Prevent Install-WindowsUpdate being called if the update doesn't apply to the OS version. 
Note: Installing the Visual Studio 2017 package on Windows Server 2016 / Windows 10 will cause this package to be installed as well (even though we don't need it), because it's a dependency. When using Boxstarter to do this, Install-WindowsUpdate will clash with Install-WindowsUpdate from Boxstarter, which then goes ahead and installs ALL critical updates. This scoping issue is more a problem for Boxstarter to fix, but in the mean time, I'd like to work around this issue by preventing Install-WindowsUpdate being called at all if the update doesn't apply to the OS.