### PR TITLE
chocolatey-visualstudio.extension: ignore NODE_OPTIONS

### DIFF
--- a/chocolatey-visualstudio.extension/extensions/Start-VSChocolateyProcessAsAdmin.ps1
+++ b/chocolatey-visualstudio.extension/extensions/Start-VSChocolateyProcessAsAdmin.ps1
@@ -105,6 +105,10 @@ Elevating Permissions and running [`"$exeToRun`" $wrappedStatements]. This may t
   if ($minimized) {
     $process.StartInfo.WindowStyle = [System.Diagnostics.ProcessWindowStyle]::Minimized
   }
+  # The Visual Studio Installer uses Electron, some versions can crash if NODE_OPTIONS is set
+  # https://github.com/electron/electron/issues/12695
+  # https://github.com/nodejs/node/issues/24360
+  $process.StartInfo.Environment.Remove("NODE_OPTIONS") | Out-Null
 
   $process.Start() | Out-Null
   if ($process.StartInfo.RedirectStandardOutput) { $process.BeginOutputReadLine() }


### PR DESCRIPTION
The current version of the Visual Studio Installer uses Electron, which will crash if `NODE_OPTIONS` is set.

This is already fixed in Electron, but until the Installer is updated it would be good to work around this by ignoring `NODE_OPTIONS`.

I tested this change and it seemed to work correctly, but feel free to change anything or give me feedback.

Fixes: https://github.com/nodejs/node/issues/24360
Refs: https://github.com/electron/electron/issues/12695