### PR TITLE
fixing visualstudio-installer's uninstall script

### DIFF
--- a/visualstudio-installer/tools/ChocolateyUninstall.ps1
+++ b/visualstudio-installer/tools/ChocolateyUninstall.ps1
@@ -1,3 +1,3 @@
 ﻿Uninstall-VisualStudio `
     -PackageName 'visualstudio-installer' `
-    -InstallerTechnology 'WillowVS2017OrLater
+    -InstallerTechnology 'WillowVS2017OrLater' `


### PR DESCRIPTION
ChocolateyUninstall script for "visualstudio-installer" fails because of missing trailing terminator.

Here is the fault:
```
ERROR: At C:\ProgramData\chocolatey\lib\visualstudio-installer\tools\ChocolateyUninstall.ps1:3 char:26
+     -InstallerTechnology 'WillowVS2017OrLater
+                          ~~~~~~~~~~~~~~~~~~~~
The string is missing the terminator: '.
visualstudio-installer uninstall not successful.
Error while running 'C:\ProgramData\chocolatey\lib\visualstudio-installer\tools\ChocolateyUninstall.ps1'.
 See log for details.
visualstudio-installer not uninstalled. An error occurred during uninstall:
 visualstudio-installer uninstall not successful.
```
After I've added terminator to the script everything's done well with no issues.