### PR TITLE
Added IncludeOptionalComponentsByDefault 

### DIFF
--- a/chocolatey-visualstudio.extension/extensions/Add-VisualStudioWorkload.ps1
+++ b/chocolatey-visualstudio.extension/extensions/Add-VisualStudioWorkload.ps1
@@ -1,4 +1,4 @@
-﻿function Add-VisualStudioWorkloadModified
+﻿function Add-VisualStudioWorkload
 {
     [CmdletBinding()]
     param(

--- a/chocolatey-visualstudio.extension/extensions/Add-VisualStudioWorkload.ps1
+++ b/chocolatey-visualstudio.extension/extensions/Add-VisualStudioWorkload.ps1
@@ -1,4 +1,4 @@
-﻿function Add-VisualStudioWorkload
+﻿function Add-VisualStudioWorkloadModified
 {
     [CmdletBinding()]
     param(
@@ -7,6 +7,7 @@
         [Parameter(Mandatory = $true)] [string] $VisualStudioYear,
         [Parameter(Mandatory = $true)] [string[]] $ApplicableProducts,
         [switch] $IncludeRecommendedComponentsByDefault,
+        [switch] $IncludeOptionalComponentsByDefault,
         [version] $RequiredProductVersion,
         [bool] $Preview
     )
@@ -22,6 +23,10 @@
     if ($IncludeRecommendedComponentsByDefault)
     {
         $argumentList += @('includeRecommended', '')
+    }
+    if ($IncludeOptionalComponentsByDefault)
+    {
+        $argumentList += @('includeOptional', '')
     }
 
     $channelReference = Get-VSChannelReference -VisualStudioYear $VisualStudioYear -Preview $Preview


### PR DESCRIPTION
I install a visual studio build tools package as a dependency, which cant specify install parameters. So ive created a wrapper package that adds the optional flag. Right now as a workaround Ive copied most of this method and invoke Start-VSModifyOperation manually, but with this change that code would be cleaner.