### PR TITLE
fix #115 Change dotnetfx 4.7.2 to use correct installer url

### DIFF
--- a/dotnetfx_previous/dotnetfx-4.7.2/dotnetfx.nuspec
+++ b/dotnetfx_previous/dotnetfx-4.7.2/dotnetfx.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>dotnetfx</id>
-    <version>4.7.2.20180712</version>
+    <version>4.7.2.20210909</version>
     <packageSourceUrl>https://github.com/jberezanski/ChocolateyPackages/tree/master/dotnetfx</packageSourceUrl>
     <owners>jberezanski</owners>
     <title>Microsoft .NET Framework 4.7.2</title>
@@ -38,6 +38,7 @@ The matching Developer Pack can be installed using [this package](https://chocol
 [.NET Framework 4.7.2 readme](https://github.com/Microsoft/dotnet/blob/master/releases/net472/README.md)
 [.NET Framework 4.7.2 changes](https://github.com/Microsoft/dotnet/blob/master/releases/net472/dotnet472-changes.md)
 ##### Package
+4.7.2.20210909: Updated the package to use correct installer url
 4.7.2.20180712: Updated installer url after .NET Framework 4.7.2 [release on Microsoft Update](https://blogs.msdn.microsoft.com/dotnet/2018/07/10/net-framework-4-7-2-is-available-on-windows-update-wsus-and-mu-catalog/) with additional quality fixes.
     </releaseNotes>
     <dependencies>

--- a/dotnetfx_previous/dotnetfx-4.7.2/tools/ChocolateyInstall.ps1
+++ b/dotnetfx_previous/dotnetfx-4.7.2/tools/ChocolateyInstall.ps1
@@ -4,8 +4,8 @@ $packageName = 'dotnetfx'
 $release = 461808
 $version = '4.7.2'
 $productNameWithVersion = "Microsoft .NET Framework $version"
-$url = 'https://download.microsoft.com/download/6/E/4/6E48E8AB-DC00-419E-9704-06DD46E5F81D/NDP472-KB4054530-x86-x64-AllOS-ENU.exe'
-$checksum = 'C908F0A5BEA4BE282E35ACBA307D0061B71B8B66CA9894943D3CBB53CAD019BC'
+$url = 'https://download.visualstudio.microsoft.com/download/pr/1f5af042-d0e4-4002-9c59-9ba66bcf15f6/089f837de42708daacaae7c04b7494db/ndp472-kb4054530-x86-x64-allos-enu.exe'
+$checksum = '5CB624B97F9FD6D3895644C52231C9471CD88AACB57D6E198D3024A1839139F6'
 $checksumType = 'sha256'
 
 if (Test-Installed -Release $release) {


### PR DESCRIPTION
The package was updated to just depend on the netfx-4.7.2 which is
considered to be supported. dotnetfx is used by end-users but
the installer URL was changed, so we update the package to work.