### PR TITLE
Update netfx-4.8 package to fix revoked certificate error preventing installation

### DIFF
--- a/netfx-4.8/netfx-4.8.nuspec
+++ b/netfx-4.8/netfx-4.8.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>netfx-4.8</id>
-    <version>4.8.0.20190930</version>
+    <version>4.8.03761</version>
     <packageSourceUrl>https://github.com/jberezanski/ChocolateyPackages/tree/master/netfx-4.8</packageSourceUrl>
     <owners>jberezanski</owners>
     <title>Microsoft .NET Framework 4.8</title>
@@ -19,9 +19,9 @@
 
 The .NET Framework provides many services, including memory management, type and memory safety, security, networking, and application deployment. It provides easy-to-use data structures and APIs that abstract the lower-level Windows operating system. You can use a variety of programming languages with the .NET Framework, including C#, F#, and Visual Basic.
 
-Supported Windows Client versions: Windows 10 version 1903, Windows 10 version 1809, Windows 10 version 1803, Windows 10 version 1709, Windows 10 version 1703, Windows 10 version 1607, Windows 8.1, Windows 7 SP1
+Supported Windows Client versions: Windows 11, Windows 10 versions: 21H2, 21H1, 20H2, 1903, 1809, 1803, 1709, 1703, 1607, Windows 8.1, Windows 7 SP1
 
-Supported Windows Server versions: Windows Server 2019, Windows Server version 1803, Windows Server 2016, Windows Server 2012 R2, Windows Server 2012, Windows Server 2008 R2 SP1
+Supported Windows Server versions: Windows Server 2022, Windows Server 2019, Windows Server version 1803, Windows Server 2016, Windows Server 2012 R2, Windows Server 2012, Windows Server 2008 R2 SP1
 
 The matching Developer Pack can be installed using [this package](https://chocolatey.org/packages/netfx-4.8-devpack).
 
@@ -35,6 +35,7 @@ On systems which have a newer version of the .NET Framework installed, this pack
 [.NET Framework 4.8 release notes](https://github.com/Microsoft/dotnet/blob/master/releases/net48/README.md)
 [.NET Framework 4.8 changes](https://github.com/Microsoft/dotnet/blob/master/releases/net48/dotnet48-changes.md)
 ##### Package
+4.8.03761: Updated installer certificate.
 4.8.0.20190930: Updated extension dependency.
     </releaseNotes>
     <dependencies>

--- a/netfx-4.8/netfx-4.8.nuspec
+++ b/netfx-4.8/netfx-4.8.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>netfx-4.8</id>
-    <version>4.8.03761</version>
+    <version>4.8.0.20220524</version>
     <packageSourceUrl>https://github.com/jberezanski/ChocolateyPackages/tree/master/netfx-4.8</packageSourceUrl>
     <owners>jberezanski</owners>
     <title>Microsoft .NET Framework 4.8</title>
@@ -35,7 +35,7 @@ On systems which have a newer version of the .NET Framework installed, this pack
 [.NET Framework 4.8 release notes](https://github.com/Microsoft/dotnet/blob/master/releases/net48/README.md)
 [.NET Framework 4.8 changes](https://github.com/Microsoft/dotnet/blob/master/releases/net48/dotnet48-changes.md)
 ##### Package
-4.8.03761: Updated installer certificate.
+4.8.0.20220524: Updated url and checksum.
 4.8.0.20190930: Updated extension dependency.
     </releaseNotes>
     <dependencies>

--- a/netfx-4.8/tools/ChocolateyInstall.ps1
+++ b/netfx-4.8/tools/ChocolateyInstall.ps1
@@ -1,11 +1,11 @@
 ﻿$version = '4.8'
 $arguments = @{
     PackageName = "netfx-$version"
-    Release = 528040
+    Release = 528049
     Version = $version
     ProductNameWithVersion = "Microsoft .NET Framework $version"
-    Url = 'https://download.visualstudio.microsoft.com/download/pr/014120d7-d689-4305-befd-3cb711108212/0fd66638cde16859462a6243a4629a50/ndp48-x86-x64-allos-enu.exe'
-    Checksum = '9B1F71CD1B86BB6EE6303F7BE6FBBE71807A51BB913844C85FC235D5978F3A0F'
+    Url = 'https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe'
+    Checksum = '68C9986A8DCC0214D909AA1F31BEE9FB5461BB839EDCA996A75B08DDFFC1483F'
     ChecksumType = 'sha256'
 }
 

--- a/netfx-4.8/tools/ChocolateyInstall.ps1
+++ b/netfx-4.8/tools/ChocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿$version = '4.8'
 $arguments = @{
     PackageName = "netfx-$version"
-    Release = 528049
+    Release = 528040
     Version = $version
     ProductNameWithVersion = "Microsoft .NET Framework $version"
     Url = 'https://download.visualstudio.microsoft.com/download/pr/2d6bb6b2-226a-4baa-bdec-798822606ff1/8494001c276a4b96804cde7829c04d7f/ndp48-x86-x64-allos-enu.exe'


### PR DESCRIPTION
The installer fetched by the `netfx-4.8` package is currently outdated and fails to install due to a [revoked certificate](https://developercommunity.visualstudio.com/t/net-framework-48-is-failing-on-windows-server-2019/1406070).

This PR updates the .NET 4.8 installer to release 528049, which successfully installs (tested on Windows 10 x64).

Let me know if I need to fix anything, first time editing a chocolatey package!