### PR TITLE
visualstudio2022-workload-manageddesktop: dependencies.

### DIFF
--- a/visualstudio2022-workload-manageddesktop/visualstudio2022-workload-manageddesktop.nuspec
+++ b/visualstudio2022-workload-manageddesktop/visualstudio2022-workload-manageddesktop.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>visualstudio2022-workload-manageddesktop</id>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packageSourceUrl>https://github.com/jberezanski/ChocolateyPackages/tree/master/visualstudio2022-workload-manageddesktop</packageSourceUrl>
     <owners>jberezanski</owners>
     <title>.NET Desktop Development workload for Visual Studio 2022</title>
@@ -27,6 +27,13 @@ The lists of components included in this workload in respective Visual Studio 20
 - [Community](https://docs.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-community?view=vs-2022#net-desktop-development)
 
 Visual Studio 2022 must be installed first, for example using Chocolatey packages: [visualstudio2022enterprise](https://chocolatey.org/packages/visualstudio2022enterprise), [visualstudio2022professional](https://chocolatey.org/packages/visualstudio2022professional), [visualstudio2022community](https://chocolatey.org/packages/visualstudio2022community).
+
+There may be potentially some dependencies that could be installed before this package. These dependencies will vary based on the targeted Visual Studio 2022 package. For example:
+
+netfx-*-devpack packages (generally one from netfx-4.7.2-devpack to netfx-4.8.1-devpack).
+dotnet-x.y-runtime, dotnet-x.y-aspnetruntime, dotnet-x.y-desktopruntime, dotnet-x.y-sdk where x.y may be 6.0, 8.0, 9.0, etc.
+
+Please look at the relevant Visual Studio 2022 documentation for your specific scenario (latest  version, specific version, LTS version, ..), or figure it out modelling the deployment of this workload on Visual Studio Installer.
 
 ### Customizations
 
@@ -68,16 +75,13 @@ Example 3. Installing the workload on all products, including only required comp
 ##### Package
 1.0.1:
 - Updated dependencies.
+1.0.2:
+- Removed context-specific dependencies.
     </releaseNotes>
     <dependencies>
       <dependency id="chocolatey-visualstudio.extension" version="1.10.0" />
       <dependency id="visualstudio-installer" version="2.0.2" />
       <dependency id="vcredist140" version="14.30.30704" />
-      <dependency id="netfx-4.7.2-devpack" version="4.7.2.20210903" />
-      <dependency id="dotnet-6.0-runtime" version="6.0.0" />
-      <dependency id="dotnet-6.0-desktopruntime" version="6.0.0" />
-      <dependency id="dotnet-6.0-aspnetruntime" version="6.0.0" />
-      <dependency id="dotnet-6.0-sdk" version="6.0.100" />
     </dependencies>
   </metadata>
 </package>


### PR DESCRIPTION
visualstudio2022-workload-manageddesktop: remove context-specific dependencies.

This is to resolve #157.